### PR TITLE
Minor fix(lecture) notebook: C1-SemistructuredAnalytics_B-lecture.ipynb comment regarding CountVectorizer.vocabulary_

### DIFF
--- a/2026/C1-SemistructuredAnalytics_B-lecture.ipynb
+++ b/2026/C1-SemistructuredAnalytics_B-lecture.ipynb
@@ -151,8 +151,25 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "# Take a look at the vocabulary which shows the total counts for whole collection\n",
+                "# Take a look at the vocabulary mapping, which shows the feature index (column position) for each word in the collection\n",
                 "count_vectorizer.vocabulary_"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "36e94db4",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Take another looks at the whole collection counts for each word\n",
+                "collection_count_df = pd.DataFrame(\n",
+                "    count_dt_matrix.toarray(),\n",
+                "    columns = count_vectorizer.get_feature_names_out()\n",
+                ").sum().sort_values(ascending=False)\n",
+                "\n",
+                "# Display the top words by actual collection frequency\n",
+                "collection_count_df"
             ]
         },
         {


### PR DESCRIPTION
# Description
This is a minor fix to the lecture notebook `C1-SemistructuredAnalytics_B-lecture.ipynb `, regarding to the cell comment of 

```
# Take a look at the vocabulary which shows the total counts for whole collection
count_vectorizer.vocabulary_
```

# The Issue
- The current comment states:
> `# Take a look at the vocabulary which shows the total counts for whole collection count_vectorizer.vocabulary_`

- This line of comment might be misleading.
- According to the `scikit-learn` documentation, the `vocabulary_` attribute returns a mapping of terms to their **feature indices** (column positions in the document-term matrix), *not* their absolute frequency counts

- For example, if `max_features=2000` is set, the maximum value found in this dictionary will always be `1999` (the last column index), regardless of how many times that word appeared in the corpus.

# The test to reproduce the issue
```
# populate the test vocabulary dataframe
test_df = pd.DataFrame.from_dict(count_vectorizer.vocabulary_, orient='index', columns=['npint']).reset_index()

# get test max np.int64
test_df[test_df['npint'] == test_df['npint'].max()]
```
- If the features count hit the `max_features` argument in the countvectorizer initialization, 
the np.int here will get that max index out
- For example, if you try `max_features=2000` and the corpus hit this max_features count,
the test cell with return last index word with the np.int of 1999.

# The fix
1. Updated the comment to match the `scikit-learn` documentation of what `vocabulary_` represents as the following:
```
# Take a look at the vocabulary mapping, which shows the feature index (column position) for each word in the collection
count_vectorizer.vocabulary_
```

2. Add another approach to get total counts
```
# Take another looks at the whole collection counts for each word
collection_count_df = pd.DataFrame(
    count_dt_matrix.toarray(),
    columns = count_vectorizer.get_feature_names_out()
).sum().sort_values(ascending=False)

# Display the top words by actual collection frequency
collection_count_df
```

> **Note That:** Some GenAI responses (especially low capability models) get this wrong as well.